### PR TITLE
fix error for relative filename

### DIFF
--- a/src/main/java/edu/jhu/nlp/wikipedia/WikiXMLParserFactory.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/WikiXMLParserFactory.java
@@ -1,5 +1,6 @@
 package edu.jhu.nlp.wikipedia;
 
+import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -10,7 +11,7 @@ import java.net.URL;
  */
 public class WikiXMLParserFactory {
     public static WikiXMLParser getSAXParser(String fileName) throws MalformedURLException {
-        return new WikiXMLSAXParser(new URL(fileName));
+        return new WikiXMLSAXParser(new File(fileName).toURL());
     }
 
     public static WikiXMLParser getSAXParser(URL fileName) {

--- a/src/test/java/edu/jhu/nlp/wikipedia/WikiXMLParserFactoryTest.java
+++ b/src/test/java/edu/jhu/nlp/wikipedia/WikiXMLParserFactoryTest.java
@@ -1,0 +1,30 @@
+package edu.jhu.nlp.wikipedia;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
+
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+
+
+public class WikiXMLParserFactoryTest {
+    @Test
+    public void testGetSAXParserFromRelativeFileName() {
+        try {
+            assertNotNull(WikiXMLParserFactory.getSAXParser("../articles.xml"));
+        } catch (MalformedURLException e) {
+            fail("relative filename should be get parser; exception:" + e);
+        }
+    }
+
+    @Test
+    public void testGetSAXParserFromAbsoluteFileName() {
+        try {
+            assertNotNull(WikiXMLParserFactory.getSAXParser("/articles.xml"));
+        } catch (MalformedURLException e) {
+            fail("relative filename should be get parser; exception:" + e);
+        }
+    }
+}


### PR DESCRIPTION
MalformedURLException occurs when WikiXMLParserFactory#getSAXParser is called with relative file name.

This PR fix this issue.
