### PR TITLE
quote replacement in wiki text stripping

### DIFF
--- a/src/main/java/edu/jhu/nlp/wikipedia/WikiTextParser.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/WikiTextParser.java
@@ -142,10 +142,11 @@ public class WikiTextParser
             int i = m.group().lastIndexOf('|');
             String replacement;
             if (i > 0) {
-                m.appendReplacement(sb, m.group(1).substring(i - 1));
+                replacement = m.group(1).substring(i - 1);
             } else {
-                m.appendReplacement(sb, m.group(1));
+                replacement = m.group(1);
             }
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
         m.appendTail(sb);
         text = sb.toString();

--- a/src/test/java/edu/jhu/nlp/wikipedia/WikiTextParserTest.java
+++ b/src/test/java/edu/jhu/nlp/wikipedia/WikiTextParserTest.java
@@ -9,8 +9,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class WikiTextParserTest extends TestCase {
@@ -76,6 +78,16 @@ public class WikiTextParserTest extends TestCase {
         assertNotNull(page.getInfoBox());
         String text = page.getText();
         assertTrue(text.indexOf("{{Infobox") == -1);
+    }
+
+    @Test
+    public void testMatcherGroupReferenceInWiki() {
+        try {
+            String text = new WikiTextParser("[[$9]]").getPlainText();
+            assertEquals("$9", text);
+        } catch (IllegalArgumentException e) {
+            fail("matcher group reference should be pasrsed");
+        }
     }
 
     // TODO: create more test cases since there really isn't any in the


### PR DESCRIPTION
IllegalArgumentException occurs when WikiTextParser stripping `[[$N]]`.

This PR fix this issue.
